### PR TITLE
[FEAT] Add CORS Middleware

### DIFF
--- a/internal/middlewares/middlewares.go
+++ b/internal/middlewares/middlewares.go
@@ -8,3 +8,10 @@ func JsonHeaderMiddleware(f http.HandlerFunc) http.HandlerFunc {
 		f(w, r)
 	}
 }
+
+func CorsHeaderMiddlware(f http.HandlerFun) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		f(w, r)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,10 @@ func main() {
 	http.HandleFunc("/bookcover", middlewares.JsonHeaderMiddleware(routes.BookcoverSearch))
 	http.HandleFunc("/bookcover/{isbn}", middlewares.JsonHeaderMiddleware(routes.BookcoverByIsbn))
 
+	http.HandleFunc("/", middlewares.CorsHeaderMiddlware(routes.Home))
+	http.HandleFunc("/bookcover", middlewares.CorsHeaderMiddlware(routes.BookcoverSearch))
+	http.HandleFunc("/bookcover/{isbn}", middlewares.CorsHeaderMiddlware(routes.BookcoverByIsbn))
+
 	fmt.Printf("Server listening at port %d 🚀\n", PORT)
 	http.ListenAndServe(":"+strconv.Itoa(PORT), nil)
 }


### PR DESCRIPTION
The suggested middleware just ensures that the proper `Access-Control-Allow-Origin` is set for this API.

Note: This was a quick fix that is untested.  Please confirm with individual testing prior to deployment.