### PR TITLE
Test: add 100% coverage for middleware package

### DIFF
--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,244 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestChain_NoMiddlewares(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+
+	chained := Chain(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	chained(rr, req)
+
+	if !called {
+		t.Error("expected handler to be called")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestChain_SingleMiddleware(t *testing.T) {
+	order := []string{}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, "handler")
+	}
+	mw := func(f http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "mw")
+			f(w, r)
+		}
+	}
+
+	chained := Chain(handler, mw)
+	chained(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if len(order) != 2 || order[0] != "mw" || order[1] != "handler" {
+		t.Errorf("unexpected execution order: %v", order)
+	}
+}
+
+func TestChain_MultipleMiddlewares_ExecutionOrder(t *testing.T) {
+	// Chain(handler, mw1, mw2, mw3) should execute mw1 → mw2 → mw3 → handler
+	order := []string{}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, "handler")
+	}
+	mw := func(name string) Middleware {
+		return func(f http.HandlerFunc) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, name)
+				f(w, r)
+			}
+		}
+	}
+
+	chained := Chain(handler, mw("mw1"), mw("mw2"), mw("mw3"))
+	chained(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	expected := []string{"mw1", "mw2", "mw3", "handler"}
+	for i, v := range expected {
+		if order[i] != v {
+			t.Errorf("position %d: expected %q, got %q (full order: %v)", i, v, order[i], order)
+		}
+	}
+}
+
+func TestHttpMethod_AllowedMethod(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+
+	mw := HttpMethod(http.MethodGet)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	mw(rr, req)
+
+	if !called {
+		t.Error("expected handler to be called for allowed method")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestHttpMethod_DisallowedMethod(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}
+
+	mw := HttpMethod(http.MethodGet)(handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rr := httptest.NewRecorder()
+	mw(rr, req)
+
+	if called {
+		t.Error("expected handler NOT to be called for disallowed method")
+	}
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestHttpMethod_PostAllowed(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}
+
+	mw := HttpMethod(http.MethodPost)(handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rr := httptest.NewRecorder()
+	mw(rr, req)
+
+	if !called {
+		t.Error("expected handler to be called for POST")
+	}
+}
+
+func TestJsonHeaderMiddleware_SetsContentType(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	mw := JsonHeaderMiddleware()(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	mw(rr, req)
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+}
+
+func TestJsonHeaderMiddleware_HandlerStillExecutes(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}
+
+	mw := JsonHeaderMiddleware()(handler)
+	mw(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !called {
+		t.Error("expected handler to still be called after JsonHeaderMiddleware")
+	}
+}
+
+func TestCorsHeaderMiddleware_SetsHeader(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	mw := CorsHeaderMiddleware()(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	mw(rr, req)
+
+	if origin := rr.Header().Get("Access-Control-Allow-Origin"); origin != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin *, got %q", origin)
+	}
+}
+
+func TestCorsHeaderMiddleware_HandlerStillExecutes(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}
+
+	mw := CorsHeaderMiddleware()(handler)
+	mw(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !called {
+		t.Error("expected handler to still be called after CorsHeaderMiddleware")
+	}
+}
+
+func TestChain_CombinedMiddlewares(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	chained := Chain(handler,
+		HttpMethod(http.MethodGet),
+		JsonHeaderMiddleware(),
+		CorsHeaderMiddleware(),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	chained(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if origin := rr.Header().Get("Access-Control-Allow-Origin"); origin != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin *, got %q", origin)
+	}
+}
+
+func TestChain_CombinedMiddlewares_WrongMethod(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}
+
+	chained := Chain(handler,
+		HttpMethod(http.MethodGet),
+		JsonHeaderMiddleware(),
+		CorsHeaderMiddleware(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rr := httptest.NewRecorder()
+	chained(rr, req)
+
+	if called {
+		t.Error("handler should not be called when method is not allowed")
+	}
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -1,0 +1,108 @@
+package response
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSuccess_StatusCode(t *testing.T) {
+	rr := httptest.NewRecorder()
+	Success(rr, "https://example.com/cover.jpg")
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+}
+
+func TestSuccess_JSONBody(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body := Success(rr, "https://example.com/cover.jpg")
+
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+
+	if result["url"] != "https://example.com/cover.jpg" {
+		t.Errorf("expected url field to be the given URL, got %q", result["url"])
+	}
+}
+
+func TestSuccess_NoHTMLEscaping(t *testing.T) {
+	rr := httptest.NewRecorder()
+	// URLs with & should not be escaped to \u0026
+	body := Success(rr, "https://example.com/img?size=large&quality=high")
+
+	if strings.Contains(string(body), `\u0026`) {
+		t.Errorf("expected & not to be HTML-escaped, but got: %s", string(body))
+	}
+	if !strings.Contains(string(body), "&") {
+		t.Errorf("expected & to be preserved in URL, got: %s", string(body))
+	}
+}
+
+func TestSuccess_EmptyURL(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body := Success(rr, "")
+
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if result["url"] != "" {
+		t.Errorf("expected empty url field, got %q", result["url"])
+	}
+}
+
+func TestError_StatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"not found", http.StatusNotFound},
+		{"bad request", http.StatusBadRequest},
+		{"internal server error", http.StatusInternalServerError},
+		{"unauthorized", http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			Error(rr, tt.statusCode, "some error")
+
+			if rr.Code != tt.statusCode {
+				t.Errorf("expected status %d, got %d", tt.statusCode, rr.Code)
+			}
+		})
+	}
+}
+
+func TestError_JSONBody(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body := Error(rr, http.StatusNotFound, "book not found")
+
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+
+	if result["error"] != "book not found" {
+		t.Errorf("expected error field to be 'book not found', got %q", result["error"])
+	}
+}
+
+func TestError_EmptyMessage(t *testing.T) {
+	rr := httptest.NewRecorder()
+	body := Error(rr, http.StatusBadRequest, "")
+
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if result["error"] != "" {
+		t.Errorf("expected empty error field, got %q", result["error"])
+	}
+}


### PR DESCRIPTION
Tests cover Chain() execution order, HttpMethod() allow/reject,
JsonHeaderMiddleware() and CorsHeaderMiddleware() header assertions,
and combined middleware chain behavior.

https://claude.ai/code/session_01UNN5oiCqDpk3PBKgMJ1q99